### PR TITLE
Fix: Remove env variable fallback from getApiKey()

### DIFF
--- a/src/utils/geminiApi.js
+++ b/src/utils/geminiApi.js
@@ -3,13 +3,9 @@
 // Storage key for API key
 const STORAGE_KEY = 'gemini_api_key';
 
-// Get API key from localStorage or env variable
+// Get API key from localStorage only
 export function getApiKey() {
-  const storedKey = localStorage.getItem(STORAGE_KEY);
-  if (storedKey) {
-    return storedKey;
-  }
-  return import.meta.env.VITE_GEMINI_API_KEY;
+  return localStorage.getItem(STORAGE_KEY);
 }
 
 // Save API key to localStorage


### PR DESCRIPTION
## Mô tả thay đổi

PR này sửa bug trong hàm `getApiKey()` bằng cách loại bỏ fallback về biến môi trường `import.meta.env.VITE_GEMINI_API_KEY`.

## Thay đổi

- ✅ Đơn giản hóa hàm `getApiKey()` để chỉ trả về giá trị từ localStorage
- ✅ Loại bỏ phụ thuộc vào biến môi trường
- ✅ Giảm độ phức tạp của code

## Code sau khi sửa

```javascript
// Get API key from localStorage only
export function getApiKey() {
  return localStorage.getItem(STORAGE_KEY);
}
```

## Testing

- [x] Hàm vẫn hoạt động bình thường khi có API key trong localStorage
- [x] Hàm trả về null khi không có API key (thay vì giá trị undefined từ env)
- [x] Logic xử lý "no API key" trong `getExplanation()` vẫn hoạt động đúng

## Related Issue

Fixes #5